### PR TITLE
feat: support switching to previous player

### DIFF
--- a/BF2AutoSpectator/game/instance_manager.py
+++ b/BF2AutoSpectator/game/instance_manager.py
@@ -970,6 +970,10 @@ class GameInstanceManager:
     def rotate_to_next_player():
         auto_press_key(0x2e)
 
+    @staticmethod
+    def rotate_to_previous_player():
+        auto_press_key(0x2c)
+
     def join_game(self) -> bool:
         if not self.is_join_game_button_visible():
             return False


### PR DESCRIPTION
I haven't been able to test this, but often I've wanted to jump back to the player we were watching. 